### PR TITLE
feat: add workflow history command

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ Goal: Make pipewright stable, reliable, and ready for real-world use.
 ### Must Have
 
 - [x] Workflow resume (`pipewright resume` — shipped in v0.4.0)
-- [ ] Workflow history (`pipewright history` — browse past runs)
+- [x] Workflow history (`pipewright history` — browse past runs)
 - [ ] Per-project config (`.pipewright.json` in project root, merged with global)
 - [x] Rate limit retry with exponential backoff (429 handling in providers)
 - [ ] Dry-run mode (`--dry-run` — preview steps, tools, and estimated cost)

--- a/src/pipewright/cli.py
+++ b/src/pipewright/cli.py
@@ -444,6 +444,83 @@ def resume(session_id: str | None, provider: str | None, yes: bool):
     )
 
 
+@main.command()
+@click.argument("session_id", required=False, default=None)
+@click.option("--workflow", "-w", default=None, help="Filter by workflow name")
+@click.option("--status", "-s", "status_filter", default="all",
+              type=click.Choice(["completed", "incomplete", "all"]),
+              help="Filter by status (default: all)")
+@click.option("--limit", "-l", default=20, help="Max sessions to show (default: 20)")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output as JSON")
+def history(session_id: str | None, workflow: str | None, status_filter: str,
+            limit: int, as_json: bool):
+    """View workflow session history.
+
+    Without arguments, lists all sessions (newest first).
+    With a session ID, shows detailed view.
+    Use 'clear' as session_id to remove all history.
+
+    Examples:
+
+        pipewright history
+
+        pipewright history a1b2c3d4e5f6
+
+        pipewright history --workflow test-gen --status completed
+
+        pipewright history --json
+
+        pipewright history clear
+    """
+    import json as json_mod
+    from dataclasses import asdict
+    from pipewright.session import Session
+    from pipewright.observability.display import session_list_row, session_detail
+
+    # Handle "clear" subcommand
+    if session_id == "clear":
+        if not as_json:
+            if not click.confirm("Delete all session history?"):
+                click.echo("Cancelled.")
+                return
+        count = Session.clear_all()
+        if as_json:
+            click.echo(json_mod.dumps({"cleared": count}))
+        else:
+            click.echo(f"Cleared {count} session(s).")
+        return
+
+    # Detail view for specific session
+    if session_id is not None:
+        session = Session.load(session_id)
+        if not session:
+            click.echo(f"Session '{session_id}' not found.")
+            raise SystemExit(1)
+        if as_json:
+            click.echo(json_mod.dumps(asdict(session), indent=2))
+        else:
+            click.echo(session_detail(session))
+        return
+
+    # List view
+    sessions = Session.list_all(workflow=workflow, status=status_filter, limit=limit)
+    if not sessions:
+        if as_json:
+            click.echo("[]")
+        else:
+            click.echo("No sessions found.")
+        return
+
+    if as_json:
+        click.echo(json_mod.dumps([asdict(s) for s in sessions], indent=2))
+        return
+
+    click.echo(f"\nSession history ({len(sessions)} sessions):\n")
+    for s in sessions:
+        click.echo(session_list_row(s))
+    click.echo(f"\nDetail: pipewright history <session-id>")
+
+
 def _to_class_name(snake_name: str) -> str:
     """Convert snake_case to PascalCase. e.g. 'my_plugin' -> 'MyPlugin'."""
     return "".join(word.capitalize() for word in snake_name.split("_"))

--- a/src/pipewright/observability/display.py
+++ b/src/pipewright/observability/display.py
@@ -107,3 +107,61 @@ def result_box(title: str, content: str):
     for line in lines:
         print(f"  {DIM}│{RESET}  {line}")
     print(f"  {BOLD}└{border}─┘{RESET}\n")
+
+
+def session_list_row(s) -> str:
+    """Format one session as a single-line list row."""
+    ts = datetime.fromtimestamp(s.updated_at).strftime("%Y-%m-%d %H:%M")
+    if s.completed:
+        status = f"{GREEN}completed{RESET}"
+    else:
+        status = f"{YELLOW}step {s.current_step}/{s.total_steps}{RESET}"
+    tgt = s.target[:30] + "..." if len(s.target) > 30 else s.target
+    return (
+        f"  {DIM}{s.id}{RESET}  {BOLD}{s.workflow_name:15s}{RESET} "
+        f"{status}  target={tgt}  {DIM}{ts}{RESET}"
+    )
+
+
+def session_detail(s) -> str:
+    """Format full session detail view."""
+    created = datetime.fromtimestamp(s.created_at).strftime("%Y-%m-%d %H:%M:%S")
+    updated = datetime.fromtimestamp(s.updated_at).strftime("%Y-%m-%d %H:%M:%S")
+    if s.completed:
+        status_str = f"{GREEN}Completed{RESET}"
+    else:
+        status_str = f"{YELLOW}In Progress ({s.current_step}/{s.total_steps}){RESET}"
+
+    lines = [
+        f"\n  {BOLD}Session {s.id}{RESET}",
+        f"  {'─' * 45}",
+        f"  Workflow:   {CYAN}{s.workflow_name}{RESET}",
+        f"  Target:     {s.target}",
+        f"  Provider:   {s.provider}",
+        f"  Model:      {s.model_alias}",
+        f"  Status:     {status_str}",
+        f"  Steps:      {s.current_step}/{s.total_steps}",
+        f"  Created:    {created}",
+        f"  Updated:    {updated}",
+    ]
+
+    if s.step_results:
+        lines.append(f"\n  {BOLD}Step Results:{RESET}")
+        total_cost = 0.0
+        total_duration = 0.0
+        for r in s.step_results:
+            skip_tag = f" {DIM}(skipped){RESET}" if r.get("skipped") else ""
+            cost = r.get("cost_usd") or 0
+            duration = r.get("duration_seconds") or 0
+            total_cost += cost
+            total_duration += duration
+            lines.append(
+                f"    {r.get('step_number', '?')}. {BOLD}{r.get('step_name', '?')}{RESET}"
+                f"  model={r.get('model', '?')}  "
+                f"${cost:.4f}  {duration:.1f}s  "
+                f"{r.get('num_turns', '?')} turns{skip_tag}"
+            )
+        lines.append(f"\n  {BOLD}Total:{RESET} ${total_cost:.4f}  {total_duration:.1f}s")
+
+    lines.append("")
+    return "\n".join(lines)

--- a/src/pipewright/session.py
+++ b/src/pipewright/session.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from pipewright.config import CONFIG_DIR
 
 SESSIONS_DIR = CONFIG_DIR / "sessions"
-MAX_SESSIONS = 10
+MAX_SESSIONS = 50
 
 
 @dataclass
@@ -74,6 +74,32 @@ class Session:
         return sessions
 
     @staticmethod
+    def list_all(
+        workflow: str | None = None,
+        status: str = "all",
+        limit: int = 20,
+    ) -> list["Session"]:
+        """List sessions with optional filters, newest first."""
+        if not SESSIONS_DIR.exists():
+            return []
+        sessions = []
+        for path in sorted(SESSIONS_DIR.glob("*.json"),
+                           key=lambda p: p.stat().st_mtime, reverse=True):
+            s = Session.load(path.stem)
+            if s is None:
+                continue
+            if workflow and s.workflow_name != workflow:
+                continue
+            if status == "completed" and not s.completed:
+                continue
+            if status == "incomplete" and s.completed:
+                continue
+            sessions.append(s)
+            if len(sessions) >= limit:
+                break
+        return sessions
+
+    @staticmethod
     def cleanup():
         """Remove old sessions, keeping only the most recent MAX_SESSIONS."""
         if not SESSIONS_DIR.exists():
@@ -83,6 +109,17 @@ class Session:
         while len(files) > MAX_SESSIONS:
             files[0].unlink()
             files.pop(0)
+
+    @staticmethod
+    def clear_all() -> int:
+        """Remove all session files. Returns count deleted."""
+        if not SESSIONS_DIR.exists():
+            return 0
+        count = 0
+        for path in SESSIONS_DIR.glob("*.json"):
+            path.unlink()
+            count += 1
+        return count
 
 
 def create_session(workflow_name: str, target: str, provider: str,

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026 Gibran Rodriguez <brangi000@gmail.com>
+# SPDX-License-Identifier: MIT
+
+"""Tests for workflow history command."""
+
+import json
+import time
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from pipewright.cli import main
+from pipewright.observability.display import session_list_row, session_detail
+from pipewright.session import Session, create_session
+
+
+def _make_session(tmp_path, name="test-gen", target="./src", provider="groq",
+                  model="haiku", steps=3, complete=False, step_results=None):
+    """Helper to create a session with optional completion and results."""
+    with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+        s = create_session(name, target, provider, model, steps)
+        if step_results:
+            s.step_results = step_results
+            s.current_step = len(step_results)
+            s.save()
+        if complete:
+            s.mark_complete()
+    return s
+
+
+class TestListAll:
+
+    def test_empty_dir(self, tmp_path):
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path / "nope"):
+            assert Session.list_all() == []
+
+    def test_returns_completed_and_incomplete(self, tmp_path):
+        _make_session(tmp_path, target="./a", complete=False)
+        _make_session(tmp_path, target="./b", complete=True)
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            sessions = Session.list_all()
+        assert len(sessions) == 2
+
+    def test_newest_first(self, tmp_path):
+        s1 = _make_session(tmp_path, target="./a")
+        time.sleep(0.05)
+        s2 = _make_session(tmp_path, target="./b")
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            sessions = Session.list_all()
+        assert sessions[0].id == s2.id
+        assert sessions[1].id == s1.id
+
+    def test_filter_by_workflow(self, tmp_path):
+        _make_session(tmp_path, name="test-gen", target="./a")
+        _make_session(tmp_path, name="code-review", target="./b")
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            sessions = Session.list_all(workflow="code-review")
+        assert len(sessions) == 1
+        assert sessions[0].workflow_name == "code-review"
+
+    def test_filter_completed(self, tmp_path):
+        _make_session(tmp_path, target="./a", complete=True)
+        _make_session(tmp_path, target="./b", complete=False)
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            sessions = Session.list_all(status="completed")
+        assert len(sessions) == 1
+        assert sessions[0].completed is True
+
+    def test_filter_incomplete(self, tmp_path):
+        _make_session(tmp_path, target="./a", complete=True)
+        _make_session(tmp_path, target="./b", complete=False)
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            sessions = Session.list_all(status="incomplete")
+        assert len(sessions) == 1
+        assert sessions[0].completed is False
+
+    def test_limit(self, tmp_path):
+        for i in range(5):
+            _make_session(tmp_path, target=f"./{i}")
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            sessions = Session.list_all(limit=2)
+        assert len(sessions) == 2
+
+
+class TestClearAll:
+
+    def test_removes_all_files(self, tmp_path):
+        _make_session(tmp_path, target="./a")
+        _make_session(tmp_path, target="./b")
+        _make_session(tmp_path, target="./c")
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            Session.clear_all()
+        assert list(tmp_path.glob("*.json")) == []
+
+    def test_returns_count(self, tmp_path):
+        _make_session(tmp_path, target="./a")
+        _make_session(tmp_path, target="./b")
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            count = Session.clear_all()
+        assert count == 2
+
+    def test_empty_dir(self, tmp_path):
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path / "nope"):
+            assert Session.clear_all() == 0
+
+
+class TestHistoryCommand:
+
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["history", "--help"])
+        assert result.exit_code == 0
+        assert "history" in result.output.lower()
+
+    def test_no_sessions(self, tmp_path):
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history"])
+        assert "No sessions found" in result.output
+
+    def test_lists_sessions(self, tmp_path):
+        s = _make_session(tmp_path)
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history"])
+        assert s.id in result.output
+        assert "test-gen" in result.output
+
+    def test_shows_completed_status(self, tmp_path):
+        _make_session(tmp_path, complete=True)
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history"])
+        assert "completed" in result.output
+
+    def test_detail_view(self, tmp_path):
+        s = _make_session(tmp_path, provider="openrouter", model="sonnet")
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history", s.id])
+        assert s.id in result.output
+        assert "test-gen" in result.output
+        assert "openrouter" in result.output
+        assert "sonnet" in result.output
+
+    def test_detail_not_found(self, tmp_path):
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history", "nonexistent123"])
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_filter_workflow(self, tmp_path):
+        _make_session(tmp_path, name="test-gen", target="./a")
+        _make_session(tmp_path, name="code-review", target="./b")
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history", "-w", "code-review"])
+        assert "code-review" in result.output
+        assert "1 sessions" in result.output
+
+    def test_filter_status(self, tmp_path):
+        _make_session(tmp_path, target="./a", complete=True)
+        _make_session(tmp_path, target="./b", complete=False)
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history", "-s", "completed"])
+        assert "1 sessions" in result.output
+
+    def test_limit_flag(self, tmp_path):
+        for i in range(5):
+            _make_session(tmp_path, target=f"./{i}")
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history", "-l", "2"])
+        assert "2 sessions" in result.output
+
+    def test_json_list(self, tmp_path):
+        _make_session(tmp_path)
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history", "--json"])
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["workflow_name"] == "test-gen"
+
+    def test_json_detail(self, tmp_path):
+        s = _make_session(tmp_path)
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history", s.id, "--json"])
+        data = json.loads(result.output)
+        assert data["id"] == s.id
+        assert data["workflow_name"] == "test-gen"
+
+    def test_clear_confirm(self, tmp_path):
+        _make_session(tmp_path, target="./a")
+        _make_session(tmp_path, target="./b")
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history", "clear"], input="y\n")
+        assert "Cleared 2 session(s)" in result.output
+        assert list(tmp_path.glob("*.json")) == []
+
+    def test_clear_cancel(self, tmp_path):
+        _make_session(tmp_path, target="./a")
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history", "clear"], input="n\n")
+        assert "Cancelled" in result.output
+        assert len(list(tmp_path.glob("*.json"))) == 1
+
+    def test_clear_json_skips_confirm(self, tmp_path):
+        _make_session(tmp_path, target="./a")
+        runner = CliRunner()
+        with patch("pipewright.session.SESSIONS_DIR", tmp_path):
+            result = runner.invoke(main, ["history", "clear", "--json"])
+        data = json.loads(result.output)
+        assert data["cleared"] == 1
+
+
+class TestDisplayFormatters:
+
+    def test_list_row_contains_id_and_workflow(self, tmp_path):
+        s = _make_session(tmp_path)
+        row = session_list_row(s)
+        assert s.id in row
+        assert "test-gen" in row
+
+    def test_list_row_truncates_long_target(self, tmp_path):
+        s = _make_session(tmp_path, target="a" * 50)
+        row = session_list_row(s)
+        assert "..." in row
+
+    def test_detail_contains_all_fields(self, tmp_path):
+        s = _make_session(tmp_path, provider="openai", model="sonnet")
+        detail = session_detail(s)
+        assert s.id in detail
+        assert "test-gen" in detail
+        assert "openai" in detail
+        assert "sonnet" in detail
+        assert "0/3" in detail
+
+    def test_detail_shows_step_costs(self, tmp_path):
+        results = [
+            {"step_name": "analyze", "step_number": 1, "model": "haiku",
+             "output_text": "ok", "cost_usd": 0.05, "num_turns": 3,
+             "duration_seconds": 2.5, "skipped": False},
+        ]
+        s = _make_session(tmp_path, step_results=results)
+        detail = session_detail(s)
+        assert "analyze" in detail
+        assert "$0.0500" in detail
+        assert "2.5s" in detail


### PR DESCRIPTION
## Summary
- Adds `pipewright history` command to browse, filter, and inspect past workflow sessions
- Increases session retention from 10 to 50 for meaningful history
- Supports list view, detail view, JSON export, filtering by workflow/status/limit, and clearing history

## Changes
- **session.py**: `list_all()` with workflow/status/limit filters, `clear_all()`, `MAX_SESSIONS` 10→50
- **display.py**: `session_list_row()` and `session_detail()` ANSI formatters
- **cli.py**: `history` command with list/detail/clear/filter/json modes
- **test_history.py**: 28 new tests (440 total passing)
- **ROADMAP.md**: Check off "Workflow history" v1.0 item

## Usage
```
pipewright history                              # list all sessions
pipewright history <id>                         # detail view
pipewright history -w test-gen -s completed     # filter
pipewright history --json                       # JSON export
pipewright history clear                        # clear with confirmation
```

## Test plan
- [x] `pytest tests/test_history.py -v` — 28 passed
- [x] `pytest tests/ -v` — 440 passed, 0 regressions