### PR TITLE
feat: add per-project config (.pipewright.json)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,7 +54,7 @@ Goal: Make pipewright stable, reliable, and ready for real-world use.
 
 - [x] Workflow resume (`pipewright resume` — shipped in v0.4.0)
 - [x] Workflow history (`pipewright history` — browse past runs)
-- [ ] Per-project config (`.pipewright.json` in project root, merged with global)
+- [x] Per-project config (`.pipewright.json` in project root, merged with global)
 - [x] Rate limit retry with exponential backoff (429 handling in providers)
 - [ ] Dry-run mode (`--dry-run` — preview steps, tools, and estimated cost)
 - [ ] Parallel step execution within workflows

--- a/src/pipewright/cli.py
+++ b/src/pipewright/cli.py
@@ -140,6 +140,34 @@ def config_get(key: str):
     click.echo(f"{key} = {val}")
 
 
+@config.command("init")
+@click.option("--force", is_flag=True, default=False, help="Overwrite existing file")
+def config_init(force: bool):
+    """Create a .pipewright.json project config in the current directory.
+
+    Example:
+
+        pipewright config init
+    """
+    import pathlib
+    import json as json_mod
+
+    target = pathlib.Path.cwd() / cfg.PROJECT_CONFIG_NAME
+    if target.exists() and not force:
+        click.echo(f"Already exists: {target}")
+        click.echo("Use --force to overwrite.")
+        raise SystemExit(1)
+
+    scaffold = {
+        "model": "haiku",
+        "provider": "anthropic",
+        "max_budget_usd": 0.50,
+    }
+    target.write_text(json_mod.dumps(scaffold, indent=2) + "\n")
+    click.echo(f"Created {target}")
+    click.echo("Edit it to set project-specific defaults.")
+
+
 @main.group()
 def memory():
     """Interact with pipewright's persistent memory."""

--- a/src/pipewright/config.py
+++ b/src/pipewright/config.py
@@ -3,8 +3,12 @@
 
 """Configuration management for Pipewright.
 
-Settings are stored in ~/.pipewright/config.json.
+Global settings are stored in ~/.pipewright/config.json.
+Per-project settings live in .pipewright.json (searched from cwd upward).
 API keys come from environment variables (never stored in config).
+
+Merge order: defaults → global config → project config.
+CLI flags and step-level overrides happen downstream in the engine.
 """
 import json
 import sys
@@ -20,6 +24,7 @@ load_dotenv(override=True)  # CWD .env can override global
 CONFIG_DIR = Path.home() / ".pipewright"
 CONFIG_FILE = CONFIG_DIR / "config.json"
 MEMORY_DIR = CONFIG_DIR / "memory"
+PROJECT_CONFIG_NAME = ".pipewright.json"
 
 # Defaults applied when no config exists yet
 DEFAULTS = {
@@ -34,8 +39,42 @@ def _ensure_dirs():
     MEMORY_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def load() -> dict:
-    """Load config, merging saved values over defaults."""
+def find_project_config(start_dir: Path | None = None) -> Path | None:
+    """Walk up from *start_dir* (default cwd) looking for .pipewright.json."""
+    current = (start_dir or Path.cwd()).resolve()
+    while True:
+        candidate = current / PROJECT_CONFIG_NAME
+        if candidate.is_file():
+            return candidate
+        parent = current.parent
+        if parent == current:  # filesystem root
+            return None
+        current = parent
+
+
+def load_project(start_dir: Path | None = None) -> dict:
+    """Load project-level config. Returns {} if not found or invalid."""
+    path = find_project_config(start_dir)
+    if path is None:
+        return {}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            print(f"Warning: project config is not a JSON object ({path}), ignoring.",
+                  file=sys.stderr)
+            return {}
+        return data
+    except json.JSONDecodeError:
+        print(f"Warning: project config corrupted ({path}), ignoring.",
+              file=sys.stderr)
+        return {}
+    except IOError:
+        return {}
+
+
+def load(project_dir: Path | None = None) -> dict:
+    """Load config, merging defaults → global → project."""
     _ensure_dirs()
     if CONFIG_FILE.exists():
         try:
@@ -49,7 +88,8 @@ def load() -> dict:
             saved = {}
     else:
         saved = {}
-    return {**DEFAULTS, **saved}
+    project = load_project(project_dir)
+    return {**DEFAULTS, **saved, **project}
 
 
 def save(cfg: dict):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,3 +125,141 @@ class TestSetValue:
         val = config_module.get("max_budget_usd")
         assert val == 2.75
         assert isinstance(val, float)
+
+
+class TestFindProjectConfig:
+    """Test find_project_config() ancestor walk."""
+
+    def test_finds_config_in_start_dir(self, tmp_path):
+        project = tmp_path / "myproject"
+        project.mkdir()
+        cfg_file = project / ".pipewright.json"
+        cfg_file.write_text('{"model": "opus"}')
+        assert config_module.find_project_config(project) == cfg_file
+
+    def test_finds_config_in_ancestor(self, tmp_path):
+        project = tmp_path / "myproject"
+        subdir = project / "src" / "deep"
+        subdir.mkdir(parents=True)
+        cfg_file = project / ".pipewright.json"
+        cfg_file.write_text('{"model": "opus"}')
+        assert config_module.find_project_config(subdir) == cfg_file
+
+    def test_returns_none_when_absent(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert config_module.find_project_config(empty) is None
+
+    def test_ignores_directories_named_pipewright_json(self, tmp_path):
+        """A directory named .pipewright.json should not match."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".pipewright.json").mkdir()  # directory, not file
+        assert config_module.find_project_config(project) is None
+
+
+class TestLoadProject:
+    """Test load_project() reading and error handling."""
+
+    def test_loads_valid_project_config(self, tmp_path):
+        cfg_file = tmp_path / ".pipewright.json"
+        cfg_file.write_text('{"model": "sonnet", "max_budget_usd": 1.00}')
+        result = config_module.load_project(tmp_path)
+        assert result == {"model": "sonnet", "max_budget_usd": 1.00}
+
+    def test_returns_empty_when_no_project_config(self, tmp_path):
+        assert config_module.load_project(tmp_path) == {}
+
+    def test_corrupted_project_config_returns_empty(self, tmp_path, capsys):
+        cfg_file = tmp_path / ".pipewright.json"
+        cfg_file.write_text("{bad json!!")
+        result = config_module.load_project(tmp_path)
+        assert result == {}
+        assert "corrupted" in capsys.readouterr().err
+
+    def test_non_object_project_config_returns_empty(self, tmp_path, capsys):
+        cfg_file = tmp_path / ".pipewright.json"
+        cfg_file.write_text('["not", "an", "object"]')
+        result = config_module.load_project(tmp_path)
+        assert result == {}
+        assert "not a JSON object" in capsys.readouterr().err
+
+
+class TestMergeOrder:
+    """Test that load() merges defaults → global → project correctly."""
+
+    def test_project_overrides_global(self, tmp_path):
+        """Project config should override global config."""
+        config_module.save({"model": "haiku", "provider": "openai"})
+        cfg_file = tmp_path / ".pipewright.json"
+        cfg_file.write_text('{"model": "opus"}')
+        result = config_module.load(project_dir=tmp_path)
+        assert result["model"] == "opus"        # project wins
+        assert result["provider"] == "openai"    # global preserved
+
+    def test_global_overrides_defaults(self):
+        """Global config should override defaults."""
+        config_module.save({"provider": "groq"})
+        result = config_module.load()
+        assert result["provider"] == "groq"
+        assert result["model"] == "haiku"  # default preserved
+
+    def test_partial_project_only_overrides_specified_keys(self, tmp_path):
+        """Project config with one key should leave others from global/defaults."""
+        config_module.save({"provider": "openai", "model": "sonnet"})
+        cfg_file = tmp_path / ".pipewright.json"
+        cfg_file.write_text('{"max_budget_usd": 0.10}')
+        result = config_module.load(project_dir=tmp_path)
+        assert result["max_budget_usd"] == 0.10
+        assert result["provider"] == "openai"
+        assert result["model"] == "sonnet"
+
+    def test_project_can_add_new_keys(self, tmp_path):
+        """Project config can introduce keys not in global or defaults."""
+        cfg_file = tmp_path / ".pipewright.json"
+        cfg_file.write_text('{"max_turns": 5, "context_limit": 500}')
+        result = config_module.load(project_dir=tmp_path)
+        assert result["max_turns"] == 5
+        assert result["context_limit"] == 500
+        assert result["provider"] == "anthropic"  # default still there
+
+
+class TestConfigInit:
+    """Test the config init CLI command."""
+
+    def test_config_init_creates_file(self, tmp_path):
+        from click.testing import CliRunner
+        from pipewright.cli import main
+
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            result = runner.invoke(main, ["config", "init"])
+            assert result.exit_code == 0
+            created = Path(td) / ".pipewright.json"
+            assert created.exists()
+            data = json.loads(created.read_text())
+            assert "model" in data
+            assert "provider" in data
+
+    def test_config_init_refuses_overwrite_without_force(self, tmp_path):
+        from click.testing import CliRunner
+        from pipewright.cli import main
+
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            Path(td, ".pipewright.json").write_text("{}")
+            result = runner.invoke(main, ["config", "init"])
+            assert result.exit_code != 0
+            assert "Already exists" in result.output
+
+    def test_config_init_force_overwrites(self, tmp_path):
+        from click.testing import CliRunner
+        from pipewright.cli import main
+
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            Path(td, ".pipewright.json").write_text("{}")
+            result = runner.invoke(main, ["config", "init", "--force"])
+            assert result.exit_code == 0
+            data = json.loads(Path(td, ".pipewright.json").read_text())
+            assert "model" in data


### PR DESCRIPTION
## Summary

- Add `.pipewright.json` support: place in project root (or any ancestor) to set project-specific defaults (model, provider, budget, etc.)
- Config merge order: defaults → global (`~/.pipewright/config.json`) → project (`.pipewright.json`) → CLI flags → step overrides
- New `pipewright config init` command scaffolds the file with `--force` to overwrite
- 15 new tests covering discovery, merging, error handling, and the CLI command (455 total, all passing)

## Test plan

- [x] `pytest tests/test_config.py -v` — 26 tests pass
- [x] `pytest tests/` — 455 tests, no regressions
- [x] Manual: create `.pipewright.json` with `{"model": "sonnet"}`, verify `pipewright config get model` returns `sonnet`
- [x] Manual: `pipewright config init` creates valid scaffold, refuses overwrite without `--force`